### PR TITLE
Escape vtex.json prop search term

### DIFF
--- a/fish/functions/fish_prompt.fish
+++ b/fish/functions/fish_prompt.fish
@@ -3,11 +3,11 @@ function parse_vtex_json
 end
 
 function get_vtex_account
-  parse_vtex_json account
+  parse_vtex_json "\"account\""
 end
 
 function get_vtex_workspace
-  parse_vtex_json workspace
+  parse_vtex_json "\"workspace\""
 end
 
 function prompt_vtex


### PR DESCRIPTION
Prevent things going wild when the `grep` returns more than one result for `workspace`/`account`

workspace: `myaccounttest`

Before: 
`[rommaneldevqab2b/myaccounttestmyaccounttest/myaccounttest]`

After: 
`[rommaneldevqab2b/myaccounttest]`