### PR TITLE
Swaps spectacle with rectangle

### DIFF
--- a/packages/Brewfile
+++ b/packages/Brewfile
@@ -15,7 +15,7 @@ cask 'google-chrome'
 cask 'google-backup-and-sync'
 cask 'iterm2'
 cask 'slack'
-cask 'spectacle'
+cask 'rectangle'
 cask 'tunnelblick'
 cask 'visual-studio-code'
 


### PR DESCRIPTION
[Spectacle](https://www.spectacleapp.com/) is an app to resize windows for mac. It is no longer being actively maintained.

[Rectangle](https://rectangleapp.com/) is another open-source alternative that has even more features, allows different sets of keybinds out of the box, and is being maintained.

Let's provision our computers with that instead :)